### PR TITLE
Add bloom filter implementation and tests

### DIFF
--- a/pkg/bloom_filter/bloom_filter.go
+++ b/pkg/bloom_filter/bloom_filter.go
@@ -1,0 +1,64 @@
+package bloomfilter
+
+import (
+	"hash"
+	"hash/fnv"
+)
+
+// BloomFilter is a probabilistic data structure that is used to test whether an element is a member of a set.
+type BloomFilter struct {
+	bits    []bool
+	hashers []hash.Hash64
+}
+
+// NewBloomFilter creates a new BloomFilter with the given size and number of hash functions.
+func NewBloomFilter(size int, numHashers int) *BloomFilter {
+	bits := make([]bool, size)
+	hashers := make([]hash.Hash64, numHashers)
+	for i := 0; i < numHashers; i++ {
+		hashers[i] = fnv.New64a()
+	}
+
+	return &BloomFilter{bits, hashers}
+}
+
+// NewBloomFilterWithAllowedFalsePositiveRate creates a new BloomFilter with the
+// given number of expected items and allowed false positive rate.
+//
+// The optimal size of the bit array and the optimal number of hash functions are calculated
+// based on the given number of expected items and allowed false positive rate.
+func NewBloomFilterWithAllowedFalsePositiveRate(n int, p float64) *BloomFilter {
+	m := GetOptimalArraySizeWithExpectedItemsAndFalsePositiveProbability(n, p)
+	k := GetOptimalHasherCountWithExpectedItemsAndOptimalArraySize(n, m)
+	return NewBloomFilter(m, k)
+}
+
+// Reset resets the BloomFilter.
+func (bf *BloomFilter) Reset() {
+	for i := range bf.bits {
+		bf.bits[i] = false
+	}
+}
+
+// Add adds an element to the BloomFilter.
+func (bf *BloomFilter) Add(data []byte) {
+	for _, hasher := range bf.hashers {
+		hasher.Write(data)
+		hash := hasher.Sum64()
+		hasher.Reset()
+		bf.bits[hash%uint64(len(bf.bits))] = true
+	}
+}
+
+// Contains checks if an element is in the BloomFilter.
+func (bf *BloomFilter) Contains(data []byte) bool {
+	for _, hasher := range bf.hashers {
+		hasher.Write(data)
+		hash := hasher.Sum64()
+		hasher.Reset()
+		if !bf.bits[hash%uint64(len(bf.bits))] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/bloom_filter/bloom_filter_test.go
+++ b/pkg/bloom_filter/bloom_filter_test.go
@@ -1,0 +1,85 @@
+package bloomfilter_test
+
+import (
+	"testing"
+
+	bloomfilter "github.com/mishramadhav/dsa/pkg/bloom_filter"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBloomFilter(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Add and Contains", func(t *testing.T) {
+		t.Parallel()
+
+		bf := bloomfilter.NewBloomFilter(100, 3)
+		bf.Add([]byte("hello"))
+		bf.Add([]byte("world"))
+
+		assert.True(t, bf.Contains([]byte("hello")), "expected 'hello' to be in the Bloom filter")
+		assert.True(t, bf.Contains([]byte("world")), "expected 'world' to be in the Bloom filter")
+		assert.False(t, bf.Contains([]byte("foo")), "expected 'foo' to not be in the Bloom filter")
+	})
+
+	t.Run("NewBloomFilterWithAllowedFalsePositiveRate", func(t *testing.T) {
+		t.Parallel()
+
+		bf := bloomfilter.NewBloomFilterWithAllowedFalsePositiveRate(100, 0.01)
+		bf.Add([]byte("hello"))
+		bf.Add([]byte("world"))
+
+		assert.True(t, bf.Contains([]byte("hello")), "expected 'hello' to be in the Bloom filter")
+		assert.True(t, bf.Contains([]byte("world")), "expected 'world' to be in the Bloom filter")
+		assert.False(t, bf.Contains([]byte("foo")), "expected 'foo' to not be in the Bloom filter")
+	})
+
+	t.Run("Reset", func(t *testing.T) {
+		t.Parallel()
+
+		bf := bloomfilter.NewBloomFilter(100, 3)
+		bf.Add([]byte("hello"))
+		bf.Add([]byte("world"))
+
+		bf.Reset()
+
+		assert.False(t, bf.Contains([]byte("hello")), "expected 'hello' to not be in the Bloom filter after reset")
+		assert.False(t, bf.Contains([]byte("world")), "expected 'world' to not be in the Bloom filter after reset")
+	})
+
+	t.Run("GetOptimalHasherCount", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			n        int
+			m        int
+			expected int
+		}{
+			{100, 1000, 7},
+			{1000, 10000, 7},
+			{10000, 100000, 7},
+		}
+
+		for _, test := range tests {
+			assert.Equal(t, test.expected, bloomfilter.GetOptimalHasherCountWithExpectedItemsAndOptimalArraySize(test.n, test.m), "unexpected number of hash functions")
+		}
+	})
+
+	t.Run("GetOptimalArraySize", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			n        int
+			p        float64
+			expected int
+		}{
+			{100, 0.01, 958},
+			{1000, 0.01, 9585},
+			{10000, 0.01, 95850},
+		}
+
+		for _, test := range tests {
+			assert.Equal(t, test.expected, bloomfilter.GetOptimalArraySizeWithExpectedItemsAndFalsePositiveProbability(test.n, test.p), "unexpected size of the bit array")
+		}
+	})
+}

--- a/pkg/bloom_filter/calculations.go
+++ b/pkg/bloom_filter/calculations.go
@@ -1,0 +1,23 @@
+package bloomfilter
+
+import "math"
+
+// GetOptimalHasherCountWithExpectedItemsAndOptimalArraySize returns the optimal number of hash functions
+// to use for a Bloom filter with n elements and m bits.
+//
+// The optimal number of hash functions is given by the formula m/n * ln(2).
+//
+// The returned number of hash functions would be an integer.
+func GetOptimalHasherCountWithExpectedItemsAndOptimalArraySize(n int, m int) int {
+	return int(math.Ceil(float64(m) / float64(n) * math.Ln2))
+}
+
+// GetOptimalArraySizeWithExpectedItemsAndFalsePositiveProbability returns the optimal size of the bit array
+// to use for a Bloom filter with n elements and a false positive probability p.
+//
+// The optimal size of the bit array is given by the formula -n * (ln(p) / ln(2)^2).
+//
+// The returned size would be an integer.
+func GetOptimalArraySizeWithExpectedItemsAndFalsePositiveProbability(n int, p float64) int {
+	return -1 * int(math.Ceil(float64(n)*math.Log(p)/math.Pow(math.Ln2, 2)))
+}


### PR DESCRIPTION
This pull request adds an implementation of a Bloom filter data structure along with corresponding tests. The Bloom filter is a probabilistic data structure used to test whether an element is a member of a set. It includes functions for adding elements to the filter, checking if an element is in the filter, and resetting the filter. Additionally, the pull request includes tests to ensure the correctness of the implementation.